### PR TITLE
Add Eleventy recipe starter

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,0 +1,18 @@
+const slugify = require('slugify');
+
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addPassthroughCopy('src/css');
+
+  eleventyConfig.addCollection('recipes', collection =>
+    collection.getFilteredByGlob('src/recipes/*.md').sort((a, b) => b.date - a.date)
+  );
+
+  eleventyConfig.addFilter('slug', str => slugify(str, { lower: true }));
+
+  return {
+    dir: {
+      input: 'src',
+      output: '_site'
+    }
+  };
+};

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run build
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          publish_dir: ./_site
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+_site/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "eleventy-recipes",
+  "private": true,
+  "scripts": {
+    "build": "eleventy",
+    "serve": "eleventy --serve"
+  },
+  "dependencies": {
+    "@11ty/eleventy": "^1.0.0",
+    "slugify": "^1.6.6"
+  }
+}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,0 +1,5 @@
+body {
+  font-family: sans-serif;
+  line-height: 1.5;
+  margin: 2rem;
+}

--- a/src/index.njk
+++ b/src/index.njk
@@ -1,0 +1,20 @@
+---
+title: Recipes
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ title }}</title>
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  <h1>{{ title }}</h1>
+  <ul>
+  {% for recipe in collections.recipes %}
+    <li><a href="{{ recipe.url }}">{{ recipe.data.title }}</a> - {{ recipe.date | date('MMMM d, yyyy') }}</li>
+  {% endfor %}
+  </ul>
+</body>
+</html>
+

--- a/src/layouts/recipe.njk
+++ b/src/layouts/recipe.njk
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ title }}</title>
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  <article>
+    <h1>{{ title }}</h1>
+    <time datetime="{{ date | date('yyyy-LL-dd') }}">{{ date | date('MMMM d, yyyy') }}</time>
+    {{ content | safe }}
+    <p>Tags: {% for tag in tags %}<a href="/tags/{{ tag | slug }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}{% endfor %}</p>
+  </article>
+</body>
+</html>

--- a/src/recipes/sample-recipe.md
+++ b/src/recipes/sample-recipe.md
@@ -1,0 +1,15 @@
+---
+title: Sample Recipe
+date: 2025-01-01
+tags: [easy, dinner]
+layout: recipe.njk
+---
+
+## Ingredients
+- 1 cup example
+- More ingredients
+
+## Instructions
+1. Do something.
+2. Serve hot.
+


### PR DESCRIPTION
## Summary
- add an Eleventy config with slug filter and recipes collection
- write index page and recipe layout
- add a sample recipe and basic CSS
- set up package.json scripts
- add GitHub Actions deploy workflow

## Testing
- `npm run build` *(fails: `eleventy` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841773186f48330b9d9b130b975600c