### PR TITLE
Fix Eleventy version mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "eleventy-recipes",
       "dependencies": {
-        "@11ty/eleventy": "^1.0.0",
+        "@11ty/eleventy": "^3.1.1",
         "slugify": "^1.6.6"
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "serve": "eleventy --serve"
   },
   "dependencies": {
-    "@11ty/eleventy": "^1.0.0",
+    "@11ty/eleventy": "^3.1.1",
     "slugify": "^1.6.6"
   }
 }


### PR DESCRIPTION
## Summary
- update Eleventy version in package.json
- update lock file accordingly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841803a77f0833082bcb7e9b14215f1