### PR TITLE
Fix CSS path for GitHub Pages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -17,6 +17,7 @@ module.exports = function(eleventyConfig) {
   );
 
   return {
+    pathPrefix: '/recipes/',
     dir: {
       input: 'src',
       output: '_site',

--- a/src/index.njk
+++ b/src/index.njk
@@ -7,7 +7,7 @@ title: Recipes
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ title }}</title>
-  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="{{ '/css/style.css' | url }}">
 </head>
 <body>
   <main class="container">

--- a/src/layouts/recipe.njk
+++ b/src/layouts/recipe.njk
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ title }}</title>
-  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="{{ '/css/style.css' | url }}">
 </head>
 <body>
   <main class="container">


### PR DESCRIPTION
## Summary
- add pathPrefix so Eleventy pages work in `/recipes/` subdirectory
- reference the pathPrefix for stylesheets

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684189c37c248330ad4bdaab6e8c86a5