### PR TITLE
Fix recipe permalinks

### DIFF
--- a/src/recipes/al-pastor.md
+++ b/src/recipes/al-pastor.md
@@ -3,7 +3,7 @@ title: Slow Cooker Al Pastor
 date: 2025-01-01
 tags: [easy, dinner]
 layout: recipe.njk
-permalink: /recipes/al-pastor/
+permalink: /al-pastor/
 ---
 
 # {{ title }}

--- a/src/recipes/orange-chicken.md
+++ b/src/recipes/orange-chicken.md
@@ -3,7 +3,7 @@ title: Orange Chicken
 date: 2025-07-02
 tags: [easy, dinner]
 layout: recipe.njk
-permalink: /recipes/orange-chicken/
+permalink: /orange-chicken/
 ---
 
 # {{ title }}


### PR DESCRIPTION
## Summary
- fix URLs for recipe pages so they work when clicked from index

## Testing
- `npm run build` *(fails: `eleventy: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686555f42eec83308780a8f58731f8ab